### PR TITLE
Clean-up/update post-commit script and add error handling

### DIFF
--- a/gitSpy/USER_KEYS.js
+++ b/gitSpy/USER_KEYS.js
@@ -1,4 +1,4 @@
-// INSERT YOUR OWN KEYS ^_^
+// INSERT YOUR OWN KEYS WITHOUT THE QUOTES ^_^
 module.exports = {
   user_id: "YOUR USER_ID HERE",
   dashboard_id: "YOUR DASHBOARD_ID HERE"

--- a/gitSpy/gitSpy.js
+++ b/gitSpy/gitSpy.js
@@ -38,7 +38,7 @@ function formatDiffs(gitDiff) {
 function main() {
   /** SERVE ERROR IF KEYS ARE NOT NUMBERS **/
   if (typeof keys.user_id != "number" ||
-    typeof key.dashboards_id != "number") {
+    typeof keys.dashboard_id != "number") {
     throwErr("Please double check that your gitSpy keys are correct!");
   }
 
@@ -56,8 +56,8 @@ function main() {
 
   /** send POST request to server **/
   var data = {
-    users_id: keys.users_id,
-    dashboards_id: keys.dashboards_id,
+    users_id: keys.user_id,
+    dashboards_id: keys.dashboard_id,
     last_pulled_commit: lastPullHash,
     diffs: diffs
   };

--- a/gitSpy/gitSpy.js
+++ b/gitSpy/gitSpy.js
@@ -2,60 +2,74 @@
 var spawnSync = require('child_process').spawnSync;
 var keys = require('./USER_KEYS');
 
+function throwErr(error) {
+  throw new Error(error);
+}
+
 function parseHash(commit) {
   var HASH_LENGTH = 40;
   return commit.substring(commit.length - HASH_LENGTH);
 }
 
-function runChildProcess(command, args, stdoutFormat) {
-  var stringifiedArgs = [];
-  for (var i = 0; i < args.length; i++) {
-    var strArg = typeof args[i] === 'string' ? args[i] : JSON.stringify(args[i]);
-    stringifiedArgs.push(strArg);
-  }
-  return spawnSync(command, stringifiedArgs, {encoding: stdoutFormat});
-}
-
 function getLastPullHash(gitLog) {
   for (var i = 0; i < gitLog.length; i++) {
     var commit = gitLog[i];
-    if (commit.indexOf('Merge pull request ') === 0 || commit.indexOf('Initial commit') === 0) {
+    if (commit.indexOf('Merge pull request ') === 0 ||
+      commit.indexOf('Initial commit') === 0) {
       return parseHash(commit);
     }
   }
-  console.log("Error: cannot find most recent pull or initial git commit");
+  throwErr("Error: cannot find most recent pull or initial git commit");
 }
 
 function formatDiffs(gitDiff) {
   var diffs = [];
   for (var i = 0; i < gitDiff.length - 1; i++) {
     var diff = gitDiff[i];
-    diffs.push({"mod_type": diff.substring(0, 1), "file": diff.substring(2)});
+    diffs.push({
+      "mod_type": diff.substring(0, 1),
+      "file": diff.substring(2),
+      "commit_message": "TO-DO"
+    });
   }
   return diffs;
 }
 
-/** Parse most recent commit hash and pull hash from git log **/
-var gitLog = runChildProcess('git', ['log', '--pretty=format:%s %H'], 'utf-8').stdout.split('\n');
-var commitHash = parseHash(gitLog[0]);
-var lastPullHash = getLastPullHash(gitLog);
+function main() {
+  /** SERVE ERROR IF KEYS ARE NOT NUMBERS **/
+  if (typeof keys.user_id != "number" ||
+    typeof key.dashboards_id != "number") {
+    throwErr("Please double check that your gitSpy keys are correct!");
+  }
 
-/** Parse and format all diffs since last merge **/
-var gitDiff = runChildProcess('git', ['diff', '--name-status', lastPullHash, commitHash], 'utf-8').stdout.split('\n');
-var diffs = formatDiffs(gitDiff);
+  /** Parse most recent commit hash and pull hash from git log **/
+  var gitLog = spawnSync('git', ['log', '--pretty=format:%s %H'],
+    {encoding: 'utf-8'}).stdout.split('\n');
+  var commitHash = parseHash(gitLog[0]);
+  var lastPullHash = getLastPullHash(gitLog);
 
-/** send POST request to server **/
-var data = {
-  users_id: "users_id", // TODO REPLACE WITH keys.user_id
-  dashboards_id: "dashboards_id", // TODO REPLACE WITH keys.project_id
-  last_pulled_commit: lastPullHash,
-  diffs: diffs
-};
-runChildProcess('curl',
-  ['-X', 'POST', '-H', 'Content-Type: application/json', '-d', data, 'http://localhost:8080/api/commits'],
-  'utf-8');
+  /** Parse and format all diffs since last merge **/
+  var gitDiff = spawnSync('git',
+    ['diff', '--name-status', lastPullHash, commitHash],
+    {encoding: 'utf-8'}).stdout.split('\n');
+  var diffs = formatDiffs(gitDiff);
 
-/** console log cute ascii art **/
-// ImageToAscii('https://s-media-cache-ak0.pinimg.com/236x/2d/8e/e8/2d8ee815146390d567706f2c7b5c2916.jpg', function(err, converted) {
-//     console.log(err || converted);
-// });
+  /** send POST request to server **/
+  var data = {
+    users_id: keys.users_id,
+    dashboards_id: keys.dashboards_id,
+    last_pulled_commit: lastPullHash,
+    diffs: diffs
+  };
+  data = JSON.stringify(data);
+  spawnSync('curl',
+    ['-X', 'POST', '-H', 'Content-Type: application/json', '-d',
+      data, 'http://gitspy.com/api/commits'],
+    {encoding: 'utf-8'});
+
+  /** console log cute ascii art **/
+  // ImageToAscii('https://s-media-cache-ak0.pinimg.com/236x/2d/8e/e8/2d8ee815146390d567706f2c7b5c2916.jpg', function(err, converted) {
+  //     console.log(err || converted);
+  // });
+}
+main();

--- a/gitSpy/gitSpyInit.js
+++ b/gitSpy/gitSpyInit.js
@@ -1,6 +1,9 @@
 var fs = require('fs');
 var spawnSync = require('child_process').spawnSync;
 
+var postCommitPath = './.git/hooks/post-commit';
+var runGitSpy = '#!/bin/sh\nnode gitSpy/gitSpy.js';
+
 function createFile(path, content) {
   if (!fs.existsSync(path)) {
     var file = fs.openSync(path, 'w');
@@ -9,15 +12,11 @@ function createFile(path, content) {
   }
 }
 
-var postCommitPath = './.git/hooks/post-commit';
-// var postMergePath = '../.git/hooks/post-merge';
-var runGitSpy = '#!/bin/sh\nnode gitSpy/gitSpy.js';
-// var updateGitSpy = '#!/bin/sh\n gitSpy/updateGitSpy.js'
+function main() {
+  /** Create pre-merge and post-commit scripts **/
+  createFile(postCommitPath, runGitSpy);
 
-/** Create post-commit and post-merge scripts **/
-createFile(postCommitPath, runGitSpy);
-// createFile(postMergePath, updateGitSpy);
-
-/** Make files executable **/
-spawnSync('chmod', ['+x', '.git/hooks/post-commit']);
-// spawnSync('chmod', ['+x', '.git/hooks/post-merge']);
+  /** Make files executable **/
+  spawnSync('chmod', ['+x', '.git/hooks/post-commit']);
+}
+main();

--- a/gitSpy/gitSpyPreCheck.js
+++ b/gitSpy/gitSpyPreCheck.js
@@ -1,0 +1,32 @@
+var spawnSync = require('child_process').spawnSync;
+
+function hasPRMerge(gitLog) {
+  for (var i = 0; i < gitLog.length; i++) {
+    var commit = gitLog[i];
+    if (commit.indexOf('Merge pull request ') === 0 ||
+      commit.indexOf('Initial commit') === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function main() {
+  /** SERVE ERROR IF GIT LOG DOESN'T CONTAIN A MERGE PR OR INITIAL COMMIT **/
+  var gitLog = spawnSync('git', ['log', '--pretty=format:%s %H'],
+    {encoding: 'utf-8'}).stdout.split('\n');
+  if (!hasPRMerge(gitLog)) {
+    throw new Error("Commit aborted\n
+      Cannot find most recent pull or initial git commit");
+  }
+
+  /** SERVE ERROR IF KEYS ARE NOT NUMBERS **/
+  if (typeof keys.user_id != "number" ||
+    typeof key.dashboards_id != "number") {
+    throw new Error("Commit aborted\n
+      Please double check that your gitSpy keys are correct!");
+  }
+
+  /**  **/
+}
+main();

--- a/gitSpy/gitSpyPreCheck.js
+++ b/gitSpy/gitSpyPreCheck.js
@@ -22,11 +22,9 @@ function main() {
 
   /** SERVE ERROR IF KEYS ARE NOT NUMBERS **/
   if (typeof keys.user_id != "number" ||
-    typeof key.dashboards_id != "number") {
+    typeof keys.dashboard_id != "number") {
     throw new Error("Commit aborted\n
       Please double check that your gitSpy keys are correct!");
   }
-
-  /**  **/
 }
 main();


### PR DESCRIPTION
#### What's this PR do?
> Adds error handling so that a POST request is not fired if the keys are not number or if there is not a PR merge or initial commit in their git history
> Connects post-commit script to user input keys
> Updated POST request to send to gitspy instead of localhost:8080

#### What are the important parts of the code?
GitSpy/GitSpy.js

#### How should this be tested by the reviewer?
If you are testing on local, you'll need to change line 47 in server.js and line 67 in gitSpy.js to localhost:8080 before testing

Run node gitSpy/gitSpyInit.js from your root directory in the terminal
Add AudibleBoulders/AudibleBoulders to your dashboards
Replace the placeholders in GitSpy/USER_KEYS.js with your own keys on set-up page
Make a test commit and see if it shows up in the dashboards page.

You can also try putting in an invalid set of keys (or no keys)
This should throw an error and not ping our server.

#### Is any other information necessary to understand this?
nope!

#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
#### Screenshots (if appropriate)