### PR TITLE
Update dashboard last_commit when user refreshes or clicks update button

### DIFF
--- a/src/client/app/dashboard/dashboard.html
+++ b/src/client/app/dashboard/dashboard.html
@@ -3,8 +3,11 @@
   <a href="#/{{dashboard.org_name}}/{{dashboard.repo_name}}/setup"><button type="button" class="btn btn-info btn-sm">Setup instructions</button></a>
 
   <h1>{{dashboard.org_name}} / <a href="{{dashboard.repo_link}}">{{dashboard.repo_name}}</a> - {{dashboard.branch}} branch</h1>
-  <h3>The sha1 of the most recent PR merge is:</h3>
-  <h3>{{dashboard.last_commit}}</h3>
+  <div class='lastCommit'>
+    <h3>The sha1 of the most recent PR merge is:</h3>
+    <h3>{{dashboard.last_commit}}</h3>
+    <span> Out of date? </span><button type="button" class="btn btn-info btn-sm" ng-click='updateLastCommit()'>Update to most recent PR merge</button>
+  </div>
 
   <div ng-repeat="user in users">
     <div ng-class="[users, { upToDate: user.up_to_date === 1, outOfDate: user.up_to_date === 0, notSetUp: user.set_up === 0 }]">

--- a/src/client/app/dashboard/dashboard.html
+++ b/src/client/app/dashboard/dashboard.html
@@ -2,9 +2,9 @@
 
   <a href="#/{{dashboard.org_name}}/{{dashboard.repo_name}}/setup"><button type="button" class="btn btn-info btn-sm">Setup instructions</button></a>
 
-  <h1>{{dashboard.org_name}} / <a href="{{dashboard.repo_link}}">{{dashboard.repo_name}}</a></h1>
-  <h3>Branch: {{dashboard.branch}}</h3>
-  <div>Last Commit: {{dashboard.last_commit}}</div>
+  <h1>{{dashboard.org_name}} / <a href="{{dashboard.repo_link}}">{{dashboard.repo_name}}</a> - {{dashboard.branch}} branch</h1>
+  <h3>The sha1 of the most recent PR merge is:</h3>
+  <h3>{{dashboard.last_commit}}</h3>
 
   <div ng-repeat="user in users">
     <div ng-class="[users, { upToDate: user.up_to_date === 1, outOfDate: user.up_to_date === 0, notSetUp: user.set_up === 0 }]">

--- a/src/client/app/dashboard/dashboard.html
+++ b/src/client/app/dashboard/dashboard.html
@@ -4,18 +4,18 @@
 
   <h1>{{dashboard.org_name}} / <a href="{{dashboard.repo_link}}">{{dashboard.repo_name}}</a> - {{dashboard.branch}} branch</h1>
   <div class='lastCommit'>
-    <h3>The sha1 of the most recent PR merge is:</h3>
+    <h3>The sha1 of this repo's most recent commit is:</h3>
     <h3>{{dashboard.last_commit}}</h3>
-    <span> Out of date? </span><button type="button" class="btn btn-info btn-sm" ng-click='updateLastCommit()'>Update to most recent PR merge</button>
+    <span> Out of date? </span><button type="button" class="btn btn-info btn-sm" ng-click='getDashboard()'>Update</button>
   </div>
 
   <div ng-repeat="user in users">
-    <div ng-class="[users, { upToDate: user.up_to_date === 1, outOfDate: user.up_to_date === 0, notSetUp: user.set_up === 0 }]">
+    <div ng-class="[users, { upToDate: user.last_pulled_commit === dashboard.last_commit, outOfDate: user.last_pulled_commit !== dashboard.last_commit, notSetUp: user.set_up === 0 }]">
       <img class="gitimg" src="{{user.github_avatar}}">
       {{user.name}} - <a href="https://github.com/{{user.git_handle}}">{{user.git_handle}}</a>
-      <span ng-show="user.up_to_date" class="alignright status"><span class="glyphicon glyphicon-ok-sign"></span></span>
-      <span ng-show="!user.up_to_date && user.set_up" class="alignright status"><span class="glyphicon glyphicon-exclamation-sign"></span></span>
-      <span ng-show="!user.up_to_date && !user.set_up" class="alignright status"><span class="glyphicon glyphicon-exclamation-sign"></span> User is not yet set up</span>
+      <span ng-show="user.last_pulled_commit === dashboard.last_commit" class="alignright status"><span class="glyphicon glyphicon-ok-sign"></span></span>
+      <span ng-show="user.last_pulled_commit !== dashboard.last_commit && user.set_up" class="alignright status"><span class="glyphicon glyphicon-exclamation-sign"></span></span>
+      <span ng-show="!user.set_up" class="alignright status"><span class="glyphicon glyphicon-exclamation-sign"></span> User is not yet set up</span>
       <div class="diffs" ng-repeat="diff in user.diffs">
         {{diff.file}} - {{diff.mod_type}} - {{diff.commit_message}}
       </div>

--- a/src/client/app/dashboard/dashboard.js
+++ b/src/client/app/dashboard/dashboard.js
@@ -23,4 +23,8 @@ angular.module('dashboard', [])
   };
 
   $scope.getDashboard();
+
+  $scope.updateLastCommit = function () {
+    console.log("updateLastCommit");
+  };
 });

--- a/src/client/app/dashboard/dashboard.js
+++ b/src/client/app/dashboard/dashboard.js
@@ -23,8 +23,4 @@ angular.module('dashboard', [])
   };
 
   $scope.getDashboard();
-
-  $scope.updateLastCommit = function () {
-    console.log("updateLastCommit");
-  };
 });

--- a/src/client/styles/style.css
+++ b/src/client/styles/style.css
@@ -20,6 +20,12 @@
   padding: 2px;
 }
 
+.lastCommit {
+  /*background-color: #a1b8e0;*/
+  background-color: #cad8ed;
+  padding: 5px 5px;
+}
+
 .upToDate {
   background-color: #c1f0c1;
   border-style: solid;

--- a/src/client/styles/style.css
+++ b/src/client/styles/style.css
@@ -21,7 +21,6 @@
 }
 
 .lastCommit {
-  /*background-color: #a1b8e0;*/
   background-color: #cad8ed;
   padding: 5px 5px;
 }

--- a/src/server/config/routes.js
+++ b/src/server/config/routes.js
@@ -14,9 +14,6 @@ var commits = require('../request-handlers/commits');
 module.exports = function (app) {
   // 'helpers.testy' is a placeholder to test routing, replace with appropriate functions
 
-  // Interact with users
-  app.post('/api/users/', users.handlePost);
-
   // Interact with dashboards
   app.post('/api/dashboards/', dashboards.handlePost);
   app.get('/api/dashboards/:githubId', dashboardsGithubId.handleGet);

--- a/src/server/request-handlers/dashboards-org-repo.js
+++ b/src/server/request-handlers/dashboards-org-repo.js
@@ -23,8 +23,8 @@ var request = require('request');
 //       id: 1,
 //       github_username: 'yaliceme',
 //       name: 'Alice',
-//       set_up: true,
-//       up_to_date: 0,
+//       set_up: 1,
+//       last_pulled_commit: 'some_sha1_hash_sdfdsfasd'
 //       diffs: [
 //         { id: 123,
 //           file: 'file/path/index.html',
@@ -80,7 +80,6 @@ module.exports = {
 
     module.exports.gitURL(githubId, commitUrl, function (commits) {
       var currentLastCommit = commits[0].sha;
-
       // Check if last_commit needs updating
       var selectStr = "SELECT last_commit FROM dashboards WHERE org_name='" + org_name + "' AND repo_name='" + repo_name + "'";
       db.query(selectStr, function (err, results) {
@@ -112,7 +111,7 @@ module.exports = {
 
         // Retrieve user details for all users that are part of this dashboard
         var dashboardId = responseObject.dashboard.id;
-        var joinStr = "SELECT users_dashboards.id, git_handle, name, github_id, github_avatar, set_up, up_to_date FROM users_dashboards INNER JOIN users ON users_dashboards.users_id=users.id WHERE dashboards_id='" + dashboardId + "'";
+        var joinStr = "SELECT users_dashboards.id, git_handle, name, github_id, github_avatar, set_up, last_pulled_commit FROM users_dashboards INNER JOIN users ON users_dashboards.users_id=users.id WHERE dashboards_id='" + dashboardId + "'";
 
         db.query(joinStr, function (err, results) {
           if (err) {

--- a/src/server/request-handlers/users.js
+++ b/src/server/request-handlers/users.js
@@ -2,10 +2,6 @@
 var db = require('../db');
 var request = require('request');
 module.exports = {
-  handlePost: function (req, res, next) {
-
-  },
-
   postUser: function (profile, token) {
     var gitId = profile.id;
     var gitHandle = profile.login;
@@ -51,13 +47,11 @@ module.exports = {
   },
 
   getToken: function (gitID, cb) {
-    console.log('gitID ', gitID);
     var tokQry = "SELECT git_token FROM users WHERE github_id='" +  gitID.toString() + "'";
     db.query(tokQry, function (err, result) {
       if (err) {
         throw new Error(err);
       } else {
-        console.log('token result: ', result[0].git_token);
         cb(result[0].git_token);
       }
     });
@@ -86,5 +80,4 @@ module.exports = {
       });
     });
   }
-
 };


### PR DESCRIPTION
#### What's this PR do?
The request handler for /api/dashboards/:orgName/:repoName now pings GitHub and updates the dashboard's last_commit if necessary, and only then begins building the responseObject. The dashboard should now appear correctly.

#### What are the important parts of the code?
dashboard request handler, dashboard.html, dashboard.js

#### How should this be tested by the reviewer?
If you have an out-of-date AudibleBoulders dashboard in your database, try pulling and running this code, viewing the dashboard for AudibleBoulders/AudibleBoulders, and inspecting the dashboards table to verify it updated in the database.

If not, try making a dummy repo and pushing some test commits up to it.

#### Is any other information necessary to understand this?
getToken and gitURL are copied verbatim from dashboards.js request handler. Eventually these and other request helpers will be factored out into their own files and required in. getToken isn't strictly necessary right now, but will be eventually if we add private repo access.

#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
Resolves #33 
#### Screenshots (if appropriate)