### PR TITLE
Add feature to start server connected to a test DB

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "start": "nodemon src/server/server.js",
     "initDB": "mysql -u root -p < src/server/schema.sql",
     "openDB": "mysql -u root -p app",
+    "initTestDB": "mysql -u root -p < src/server/test-schema.sql",
+    "openTestDB": "mysql -u root -p test",
+    "addTestData": "npm run initTestDB && mysql -u root < src/server/test-data/test-data.sql",
     "lint": "jshint src",
     "test": "karma start karma.conf.js",
     "forever" : "forever start src/server/server.js"

--- a/src/server/db/index.js
+++ b/src/server/db/index.js
@@ -1,27 +1,23 @@
 /*jslint node: true */
 "use strict";
-var PORT = require('../server');
-var express = require('express');
 var mysql = require('mysql');
-var app = express();
-// Setup Pool for MySql DB
-
-var password = (PORT === 8080) ? '' : 'raad39';
-var pool = mysql.createPool({
-  connectionLimit : 200, //important
-  host     : 'localhost',
-  user     : 'root',
-  password : password,
-  database : 'app',
-  debug    :  false
-});
+var pool = null;
 
 module.exports = {
-
+  createPool: function(database, PORT) {
+    var password = (PORT === 8080) ? '' : 'raad39';
+    pool  = mysql.createPool({
+      connectionLimit : 200,
+      host     : 'localhost',
+      user     : 'root',
+      password : password,
+      database : database,
+      debug    :  false
+    });
+  },
   getConnection : function(callback) {
     pool.getConnection(function(err, connection) {
       callback(err, connection);
     });
   }
 };
-

--- a/src/server/dropDB.sql
+++ b/src/server/dropDB.sql
@@ -1,1 +1,0 @@
-DROP DATABASE app;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,17 +1,24 @@
 /*jshint loopfunc: true */
 "use strict";
+
+/** Create Server and Set Port **/
 var PORT = module.exports = process.env.PORT || 8080; // Set port
 var express = require('express');
 var app = express();
-var path = require('path');
-var bodyparser = require('body-parser');
+
+/** Create DB Connection and Require User Queries**/
+var db = module.parent ?
+  require('./db').createPool('test', PORT) : require('./db').createPool('app', PORT);
+var users = require('./request-handlers/users.js');
+
+/** Github Auth and Sessions **/
 var keys = require('./config/keys.js');
 var passport = require('passport');
 var cookieparser = require('cookie-parser');
 var GithubStrategy = require('passport-github2').Strategy;
 var session = require('express-session');
-var db = require('./db');
-var users = require('./request-handlers/users.js');
+
+/** Socket Dependencies **/
 var http = require('http').Server(app);
 var io = require('socket.io')(http);
 

--- a/src/server/test-data/test-data.sql
+++ b/src/server/test-data/test-data.sql
@@ -1,4 +1,4 @@
-USE app;
+USE test;
 
 INSERT into users (id, git_handle, name, github_id, github_avatar) VALUES (1, "yaliceme", "Alice Yu", "123", "alice.jpg");
 INSERT into users (id, git_handle, name, github_id, github_avatar) VALUES (2, "rhombus33", "Diamond Wheeler", "456", "diamond.jpg");

--- a/src/server/test-schema.sql
+++ b/src/server/test-schema.sql
@@ -1,0 +1,64 @@
+DROP DATABASE IF EXISTS test;
+
+CREATE DATABASE test;
+
+USE test;
+
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE users (
+  id int NOT NULL AUTO_INCREMENT,
+  git_handle varchar(39) NOT NULL UNIQUE,
+  name varchar(256),
+  signature varchar(200),
+  github_id varchar(200),
+  github_avatar varchar(200),
+  git_token varchar(200),
+  PRIMARY KEY (id)
+);
+
+DROP TABLE IF EXISTS dashboards;
+
+CREATE TABLE dashboards (
+  id int NOT NULL AUTO_INCREMENT,
+  repo_link varchar(200) NOT NULL,
+  branch varchar(200),
+  org_name varchar(200),
+  repo_name varchar(200),
+  last_commit varchar(200),
+  PRIMARY KEY (id)
+);
+
+DROP TABLE IF EXISTS users_dashboards;
+
+CREATE TABLE users_dashboards (
+  id int NOT NULL AUTO_INCREMENT,
+  users_id int NOT NULL,
+  dashboards_id int NOT NULL,
+  set_up tinyint,
+  up_to_date tinyint,
+  last_pulled_commit varchar(200),
+  PRIMARY KEY (id),
+  FOREIGN KEY (users_id)
+    REFERENCES users(id),
+  FOREIGN KEY (dashboards_id)
+    REFERENCES dashboards(id)
+);
+
+DROP TABLE IF EXISTS diffs;
+
+CREATE TABLE diffs (
+  id int NOT NULL AUTO_INCREMENT,
+  users_dashboards_id int NOT NULL,
+  file varchar(200),
+  mod_type varchar(20),
+  commit_message varchar(200),
+  PRIMARY KEY (id),
+  FOREIGN KEY (users_dashboards_id)
+    REFERENCES users_dashboards(id)
+);
+
+
+/*  Execute this file from the command line by typing:
+ *    mysql -u root < src/server/schema.sql
+ *  from project root to create the database and the tables.*/

--- a/src/server/test.js
+++ b/src/server/test.js
@@ -1,0 +1,1 @@
+var server = require("./server.js");


### PR DESCRIPTION
#### What's this PR do?
Add logic in server to connect to the production OR test db depending on how it is called.
Add seperate schema and scripts for testDB 

#### What are the important parts of the code?
Important changes are in server.js and db/index.js
Also added extra schema and some scripts into package.json
Removed a ghost file (dropDB.sql)

#### How should this be tested by the reviewer?
Run "npm run initDB" and "npm run initTestDB" to create/clear both DBs
/** testing the production DB **/
Start the server using "npm start" and navigate our site and insert some stuff into our "app" db
Run "npm run openDB" to see that the data was indeed inserted into the "app" DB

/** testing the test DB **/
Now, start the server using "node src/server/test.js" and insert some stuff into our "test" db
     (add diff things this time!!)
Run "npm run openTestDB" to see that the data was indeed inserted into the "test" DB

#### Is any other information necessary to understand this?
N/A

#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
N/A

#### Screenshots (if appropriate)
N/A