### PR TITLE
Make passport call updateOrCreate directly, login working

### DIFF
--- a/src/server/new-request-handlers/users.js
+++ b/src/server/new-request-handlers/users.js
@@ -2,95 +2,31 @@
 
 var request = require('request');
 var pool = require('../db/index.js');
+var users = require('../queries/users.js');
 
 module.exports = {
-  postUser: function (profile, token) {
-    var gitId = profile.id;
-    var gitHandle = profile.login;
-    var avatar = profile.avatar_url;
-    var name = profile.name;
-    var userQry = "SELECT id FROM users WHERE github_id='" + gitId.toString() + "'";
-    // Check if user is in table
-    pool.getConnection(function(err, connection){
-      if(err) {
-        throw err;
-      }
-      connection.query(userQry, function (err, results) {
-        if (err) {
-          throw new Error(err);
-        }
-        // If user NOT in table, add user
-        if (results.length === 0) {
-          var addUser = "INSERT into users (git_handle, name, github_id, github_avatar, git_token) VALUES ('"+ gitHandle +"','"+ name +"','"+ gitId +"','"+ avatar +"','"+ token +"')";
-          connection.query(addUser, function (err, results) {
-            if (err) {
-              throw new Error(err);
-            } else {
-              return results;
-            }
-          });
-        } else {
-          // If user is in the table check if git token has changed
-          var tokenQry = "SELECT git_token FROM users where github_id='" +gitId.toString()+ "'";
-          connection.query(tokenQry, function(err, result) {
-            if (err) {
-              throw new Error(err);
-            } else if(result[0].git_token !== token){
-              // If the tokens are not equal update token
-              var updateToken = "UPDATE users SET git_token='"+token+"' WHERE github_id='"+gitId+"'";
-              connection.query(updateToken, function (err, results) {
-                if (err) {
-                  throw new Error(err);
-                } else {
-                  return results;
-                }
-              });
-              return result;
-            }
-          });
-        }
-      });
-    });
-  },
-
-  getToken: function (gitID, cb) {
-    var tokQry = "SELECT git_token FROM users WHERE github_id='" +  gitID.toString() + "'";
-    pool.getConnection(function(err, connection){
-      if(err) {
-        throw err;
-      }
-      connection.query(tokQry, function (err, result) {
-        if (err) {
-          throw new Error(err);
-        } else {
-          console.log('token result: ', result[0].git_token);
-          cb(result[0].git_token);
-        }
-      });
-    });
-  },
-
   userSub: function (req, res, next) {
-    var id  = req.cookies.githubId;
-    var gitHandle = req.cookies.githubName;
-    var token;
-    module.exports.getToken(id,function(token){
-      token = token;
-      var options = {
-        url: "https://api.github.com/user/repos",
-        headers: {
-          'User-Agent': 'GitSpy',
-          authorization: 'token '+ token,
-          'content-type': 'application/json'
-        },
-      };
-      request.get(options, function(error, response, body) {
-        if (error){
-          throw new Error(error);
-        } else {
-          res.end(body);
-        }
+    var githubId  = req.cookies.githubId;
+    users.getOneAsync(githubId)
+      .then(function (userObject) {
+        var options = {
+          url: "https://api.github.com/user/repos",
+          headers: {
+            'User-Agent': 'GitSpy',
+            authorization: 'token '+ userObject.github_token,
+            'content-type': 'application/json'
+          },
+        };
+        request.get(options, function(error, response, body) {
+          if (error){
+            throw new Error(error);
+          } else {
+            res.end(body);
+          }
+        });
+      })
+      .catch(function (err) {
+        console.error(err);
       });
-    });
   }
 };

--- a/src/server/queries/users.js
+++ b/src/server/queries/users.js
@@ -67,9 +67,17 @@ var users = module.exports = promise.promisifyAll({
       }
     });
   },
-  updateOrCreate: function (userObject, callback) {
-    // userObject should include properties for all users fields
+  updateOrCreate: function (profile, token, callback) {
+    // profile and token are what's received from passport
+    // sample input for profile: https://api.github.com/user/2690580
     // no return value
+    var userObject = {
+      github_id: profile.id,
+      github_handle: profile.login,
+      github_name: profile.name,
+      github_avatar: profile.avatar_url,
+      github_token: token
+    };
 
     // call getOne to see if user already exists
     users.getOne(userObject.github_id, function (err, result) {

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -9,7 +9,7 @@ var app = express();
 /** Create DB Connection and Require User Queries**/
 var db = module.parent ?
   require('./db').createPool('test', PORT) : require('./db').createPool('app', PORT);
-var users = require('./new-request-handlers/users.js');
+var users = require('./queries/users.js');
 
 /** Github Auth and Sessions **/
 var keys = require('./config/keys.js');
@@ -62,7 +62,9 @@ function (accessToken, refreshToken, profile, done) {
   // TODO: DB query to create profile id, change to access DB
   process.nextTick(function () {
     token(accessToken);
-    users.postUser(profile._json, accessToken);
+    users.updateOrCreate(profile._json, accessToken, function (err, result) {
+      if (err) throw new Error(err);
+    });
     return done(null, profile._json);
   });
 }));


### PR DESCRIPTION
#### What's this PR do?
Login now works with refactored code

#### What are the important parts of the code?
- In server.js, passport now calls updateOrCreate directly
- In queries/users.js, tweaked args to updateOrCreate to accommodate this
- Removed unnecessary postUser from new-request-handlers/users.js
- Refactored userSub to use queries

#### How should this be tested by the reviewer?
Pull down and verify that login works (though dashboard etc won't load yet)

#### Is any other information necessary to understand this?
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
#### Screenshots (if appropriate)