### PR TITLE
#/add now works with new POST /api/dashboards request handler

### DIFF
--- a/src/client/app/add/add.js
+++ b/src/client/app/add/add.js
@@ -108,9 +108,10 @@ angular.module('add', [])
   };
 
   $scope.postDashboard = function (repoObject) {
-    RequestFactory.postDashboard(repoObject)
+    var dashboardInfo = {org_name: repoObject.owner.login, repo_name: repoObject.name};
+    RequestFactory.postDashboard(dashboardInfo)
     .then(function () {
-      emitJoinDash(repoObject);
+      emitJoinDash(dashboardInfo);
     });
   };
 }]);

--- a/src/client/app/services/services.js
+++ b/src/client/app/services/services.js
@@ -34,11 +34,11 @@ helper.factory('RequestFactory', function($http) {
     });
   };
 
-  var postDashboard = function(newDashboard) {
+  var postDashboard = function(dashboardInfo) {
     return $http({
       method: 'POST',
       url: '/api/dashboards/',
-      data: newDashboard
+      data: dashboardInfo
     })
     .then(function (res) {
       return res.data;

--- a/src/server/config/routes.js
+++ b/src/server/config/routes.js
@@ -15,10 +15,10 @@ var repos = require('../new-request-handlers/repos.js');
 
 module.exports = function (app) {
   // Interact with dashboards
-  app.post('/api/dashboards/', dashboards.handlePost);
-  app.get('/api/dashboards/:githubId', dashboardsGithubId.handleGet);
-  app.get('/api/dashboards/:orgName/:repoName', dashboardsOrgRepo.handleGet);
-  app.delete('/api/users_dashboards/:githubId/:dashboardId', usersDashboards.handleDelete);
+  app.post('/api/dashboards/', dashboards.handlePost); // for when user joins and/or creates a dashboard from #/add
+  app.get('/api/dashboards/:githubId', dashboardsGithubId.handleGet); // for displaying all dashboards user has already joined, on #/home
+  app.get('/api/dashboards/:orgName/:repoName', dashboardsOrgRepo.handleGet); // for getting all information needed to render a particular #/:orgName/:repoName dashbaorad
+  app.delete('/api/users_dashboards/:githubId/:dashboardId', usersDashboards.handleDelete); // for when user removes themselves from a dashboard by clicking x on #/
 
   // Get signature hash etc for setup page
   app.get('/api/setup/:orgName/:repoName/:githubId', setup.handleGet);

--- a/src/server/new-request-handlers/dashboards.js
+++ b/src/server/new-request-handlers/dashboards.js
@@ -1,132 +1,31 @@
 "use strict";
 
-var request = require('request');
-var pool = require('../db/index.js');
+var dashboards = require('../queries/dashboards');
+var users_dashboards = require('../queries/users_dashboards');
 
 module.exports = {
-  // Function to grab specified users Git Token
-  getToken: function (gitID, cb) {
-    var tokQry = "SELECT git_token FROM users WHERE github_id='" +  gitID.toString() + "'";
-    pool.getConnection(function(err, connection){
-      if(err) {
-        throw err;
-      }
-      connection.query(tokQry, function (err, result) {
-        if (err) {
-          throw new Error(err);
-        } else {
-          cb(result[0].git_token);
-        }
-      });
-    });
-  },
-  // Function to grab Information from specified URL
-  gitURL: function (id, url, callback) {
-    var token;
-    module.exports.getToken(id,function(token){
-      token = token;
-      var options = {
-        url: url,
-        headers: {
-          'User-Agent': 'GitSpy',
-          authorization: 'token '+ token,
-          'content-type': 'application/json'
-        },
-      };
-      request.get(options, function(error, response, body) {
-        if (error){
-          throw new Error(error);
-        } else {
-          callback(JSON.parse(body));
-        }
-      });
-    });
-  },
-  // Update Database with new repo information for Dashboard
   handlePost: function (req, res, next) {
     var githubId = req.cookies.githubId;
-    var commitUrl = req.body.commits_url;
-    commitUrl = commitUrl.slice(0,commitUrl.length-6);
-    var commits;
-    // Function to grab commit information
-    module.exports.gitURL(githubId, commitUrl, function(commits){
-      commits = commits;
-      var last_commit = commits[0].sha;
-      var dashboardDetails = {};
-      dashboardDetails.repo_link = req.body.html_url;
-      dashboardDetails.branch = req.body.default_branch;
-      dashboardDetails.org_name = req.body.owner.login;
-      dashboardDetails.repo_name = req.body.name;
-      dashboardDetails.last_commit = last_commit;
+    var orgName = req.body.org_name;
+    var repoName = req.body.repo_name;
 
-      // find users_id based on githubId
-      var selectStr = "SELECT id FROM users WHERE github_id='" + githubId.toString() + "';";
-      pool.getConnection(function(err, connection){
-        if(err) {
-          throw err;
-        }
-        connection.query(selectStr, function (err, results) {
-          if (err) {
-            throw new Error (err);
-          }
-          if (results.length === 0) {
-            console.log("user with this github_id is not found");
-          } else {
-            var users_id = results[0].id;
-            // find or create the dashboard
-            var findDashboard = "SELECT * FROM dashboards WHERE repo_link='" + dashboardDetails.repo_link.toString() + "';";
-            // Check if dashboard exists
-            connection.query(findDashboard, function (err, results) {
-              if (err) {
-                throw new Error(err);
-              }
-              if (results.length === 0) {
-                // Dashboard DOES NOT exist. Create dashboard and associate user to the dashboard
-                var createDashboard = "INSERT INTO dashboards (repo_link, branch, org_name, repo_name, last_commit) VALUES ('" + dashboardDetails.repo_link + "', '" + dashboardDetails.branch + "', '" + dashboardDetails.org_name + "', '" + dashboardDetails.repo_name + "', '" + dashboardDetails.last_commit + "');";
-                connection.query(createDashboard, function (err, results) {
-                  if (err) {
-                    throw new Error(err);
-                  }
-                  var dashboards_id = results.insertId;
-                  var associateUser = "INSERT INTO users_dashboards (users_id, dashboards_id, set_up, up_to_date) VALUES ('" + users_id.toString() + "', '" + dashboards_id.toString() + "', '0', '0');";
-                  connection.query(associateUser, function (err, results) {
-                    if (err) {
-                      throw new Error(err);
-                    } else {
-                      console.log('Successfully inserted into users_dashboards table');
-                      res.status = 201;
-                      res.json(results);
-                    }
-                  });
-                });
-              } else {
-                // Dashboard DOES exist. Check if user is already associated to dashboard, if not create the association.
-                var dashboards_id = results[0].id;
-                var checkUsersDashboard = "SELECT * FROM users_dashboards WHERE users_id='" + users_id.toString() + "' AND dashboards_id='" + dashboards_id.toString() + "'";
-                connection.query(checkUsersDashboard, function (err, results) {
-                  if (err) {
-                    throw new Error(err);
-                  }
-                  if (results.length === 0) {
-                    var associateUser = "INSERT INTO users_dashboards (users_id, dashboards_id, set_up, up_to_date) VALUES ('" + users_id.toString() + "', '" + dashboards_id.toString() + "', '0', '0');";
-                    connection.query(associateUser, function (err, results) {
-                      if (err) {
-                        throw new Error(err);
-                      } else {
-                        res.status = 201;
-                        res.json(results);
-                      }
-                    });
-                  } else {
-                    res.status = 201;
-                    res.json(results);
-                  }
-                });
+    // find or create the dashboard
+    dashboards.findOrCreateAsync(orgName, repoName)
+      .then(function (result) {
+        if (result.isNewDashboard) {
+          // dashboard is new, add users_dashboards record immediately
+          users_dashboards.addOneAsync(githubId, result.dashboards_id);
+        } else {
+          // dashboard exists already, check if users_dashboards record also exists already
+          var dashboardId = result.dashboards_id;
+          users_dashboards.getOneAsync(githubId, dashboardId)
+            .then(function (result) {
+              if (!result) {
+                // users_dashboards record does not yet exist, add it
+                users_dashboards.addOneAsync(githubId, dashboardId);
               }
             });
-          }
-        });
+        }
       });
-    });
   }
 };

--- a/src/server/new-request-handlers/dashboards.js
+++ b/src/server/new-request-handlers/dashboards.js
@@ -16,7 +16,7 @@ module.exports = {
           // dashboard is new, add users_dashboards record immediately
           users_dashboards.addOneAsync(githubId, result.dashboards_id)
             .then(function () {
-              res.end(201);
+              res.sendStatus(201);
             });
         } else {
           // dashboard exists already, check if users_dashboards record also exists already
@@ -27,10 +27,10 @@ module.exports = {
                 // users_dashboards record does not yet exist, add it
                 users_dashboards.addOneAsync(githubId, dashboardId)
                   .then(function () {
-                    res.end(201);
+                    res.sendStatus(201);
                   });
               } else {
-                res.end(200);
+                res.sendStatus(200);
               }
             });
         }

--- a/src/server/new-request-handlers/dashboards.js
+++ b/src/server/new-request-handlers/dashboards.js
@@ -14,7 +14,10 @@ module.exports = {
       .then(function (result) {
         if (result.isNewDashboard) {
           // dashboard is new, add users_dashboards record immediately
-          users_dashboards.addOneAsync(githubId, result.dashboards_id);
+          users_dashboards.addOneAsync(githubId, result.dashboards_id)
+            .then(function () {
+              res.end(201);
+            });
         } else {
           // dashboard exists already, check if users_dashboards record also exists already
           var dashboardId = result.dashboards_id;
@@ -22,7 +25,12 @@ module.exports = {
             .then(function (result) {
               if (!result) {
                 // users_dashboards record does not yet exist, add it
-                users_dashboards.addOneAsync(githubId, dashboardId);
+                users_dashboards.addOneAsync(githubId, dashboardId)
+                  .then(function () {
+                    res.end(201);
+                  });
+              } else {
+                res.end(200);
               }
             });
         }

--- a/src/server/new-request-handlers/users.js
+++ b/src/server/new-request-handlers/users.js
@@ -21,7 +21,7 @@ module.exports = {
           if (error){
             throw new Error(error);
           } else {
-            res.end(JSON.stringify(response));
+            res.json(response);
           }
         });
       })

--- a/src/server/new-request-handlers/users.js
+++ b/src/server/new-request-handlers/users.js
@@ -15,13 +15,13 @@ module.exports = {
             'User-Agent': 'GitSpy',
             authorization: 'token '+ userObject.github_token,
             'content-type': 'application/json'
-          },
+          }
         };
         request.get(options, function(error, response, body) {
           if (error){
             throw new Error(error);
           } else {
-            res.end(body);
+            res.end(JSON.stringify(response));
           }
         });
       })

--- a/src/server/queries/users_dashboards.js
+++ b/src/server/queries/users_dashboards.js
@@ -18,7 +18,7 @@ var users_dashboards = module.exports = promise.promisifyAll({
   },
   addOne: function (githubId, dashboardId, callback) {
     // use simple githubId + dashboardId concatenation for "hash" for now, guarantees uniqueness. substitute a proper hash later
-    var signatureHash = githubId.toString + '@' + dashboardId.toString();
+    var signatureHash = githubId.toString() + '@' + dashboardId.toString();
     var insertStr = "INSERT INTO users_dashboards (users_github_id, dashboards_id, set_up, signature_hash) VALUES (" + githubId.toString() + ", " + dashboardId.toString() + ", 0, '" + signatureHash + "');";
     pool.query(insertStr, function (err, results) {
       if (err) {


### PR DESCRIPTION
#### What's this PR do?
Makes it so that clicking on things in #/add now correctly inserts things into database, with new-request-handlers/dashboards.js refactored to use new queries.

#### What are the important parts of the code?
new-request-handlers/dashboards.js

#### How should this be tested by the reviewer?
Pull down and verify that clicking on stuff in #/add inserts what you'd expect into db. Visual inspection of code.

#### Is any other information necessary to understand this?
Clicking does not redirect to the dashboard currently, I think that may be because we haven't refactored the /api/dashboards/:orgName/:repoName request handler yet. In any case, I think we can fix it in a future PR.

#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
#### Screenshots (if appropriate)