### PR TITLE
Redirect upon add, escape query inputs for updateLastCommit

### DIFF
--- a/src/client/app/add/add.js
+++ b/src/client/app/add/add.js
@@ -111,7 +111,7 @@ angular.module('add', [])
     var dashboardInfo = {org_name: repoObject.owner.login, repo_name: repoObject.name};
     RequestFactory.postDashboard(dashboardInfo)
     .then(function () {
-      emitJoinDash(dashboardInfo);
+      emitJoinDash(repoObject);
     });
   };
 }]);

--- a/src/server/queries/dashboards.js
+++ b/src/server/queries/dashboards.js
@@ -24,8 +24,7 @@ var dashboards = module.exports = promise.promisifyAll({
   },
   updateLastCommit: function (orgName, repoName, newSha1, newMsg, callback) {
     // no return value
-    var updateStr = "UPDATE dashboards SET last_commit_sha1='" + newSha1 + "', last_commit_msg='" + newMsg + "' WHERE org_name='" + orgName + "' AND repo_name='" + repoName + "';";
-    pool.query(updateStr, function (err, results) {
+    pool.query("UPDATE dashboards SET last_commit_sha1=?, last_commit_msg=? WHERE org_name=? AND repo_name=?", [newSha1, newMsg, orgName, repoName], function (err, results) {
       callback(err, results);
     });
   },


### PR DESCRIPTION
#### What's this PR do?
Redirect works again, after clicking on a repo on #/add. 
Does query input escaping (sanitizing input) for updateLastCommit in queries/dashboards.js

#### What are the important parts of the code?
add.js
queries/dashboards.js

#### How should this be tested by the reviewer?
Pull down and verify that clicking on stuff in #/add redirects you to that dashboard.

#### Is any other information necessary to understand this?
Eventually we'll want to sanitize query inputs for ALL our queries. I did just this one query for now.

#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
#### Screenshots (if appropriate)