### PR TITLE
Replace for loop with a forEach to fix dashboard bug

### DIFF
--- a/src/server/new-request-handlers/dashboards-org-repo.js
+++ b/src/server/new-request-handlers/dashboards-org-repo.js
@@ -69,10 +69,7 @@ module.exports = {
       })
       .then(function (dashboardUsers) {
         var usersWithSigHashes = dashboardUsers;
-
-        for (var i = 0; i < usersWithSigHashes.length; i++) {
-          var thisUser = usersWithSigHashes[i];
-
+        usersWithSigHashes.forEach(function (thisUser) {
           diffs.getAllAsync(thisUser.signature_hash)
             .then(function (diffsArray) {
               responseObject.users.push({
@@ -89,7 +86,7 @@ module.exports = {
                 res.json(responseObject);
               }
             });
-        }
+        });
       });
   }
 };


### PR DESCRIPTION
#### What's this PR do?
Fixes dashboard bug where the same person showed up multiple times.

#### What are the important parts of the code?
dashboards-org-repo request handler

#### How should this be tested by the reviewer?
Pull down, run, go to a dashboard that has multiple users, verify that it displays as expected.

#### Is any other information necessary to understand this?
The problem had to do with the for loop in which you would query the diffs table for every user. By the time you attach that info to the responseObject, thisUser is bound to the last user in the usersWithSigHash array. forEach fixes this by blocking each iteration until the previous one is complete. We might want to move to a Promise.bind pattern for possible performance gains, but forEach definitely works for now.

#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
#### Screenshots (if appropriate)