### PR TITLE
Call out potential conflicts on dashboard page

### DIFF
--- a/src/client/app/dashboard/dashboard.html
+++ b/src/client/app/dashboard/dashboard.html
@@ -21,6 +21,13 @@
       Most recent commit at github.com/{{orgName}}/{{repoName}}: <span>{{dashboard.last_commit_sha1}}</span>
     </div>
 
+    <div class="conflicts">
+      Potential conflicts:
+      <ul>
+        <li ng-repeat="conflict in conflicts">{{conflict.file}} has been touched by:<span ng-repeat="user in conflict.users"> {{user.github_handle}}</span></li>
+      </ul>
+    </div>
+
     <div class="dashboardUser" ng-repeat="user in users">
       <div ng-class="[users, { upToDate: user.last_pulled_commit_sha1 === dashboard.last_commit_sha1, outOfDate: user.last_pulled_commit_sha1 !== dashboard.last_commit_sha1, notSetUp: user.set_up === 0 }]">
         <div class="dashboardUserCommit">

--- a/src/client/app/dashboard/dashboard.html
+++ b/src/client/app/dashboard/dashboard.html
@@ -21,10 +21,10 @@
       Most recent commit at github.com/{{orgName}}/{{repoName}}: <span>{{dashboard.last_commit_sha1}}</span>
     </div>
 
-    <div class="conflicts">
+    <div class="potentialConflicts" ng-show="conflicts.length">
       Potential conflicts:
       <ul>
-        <li ng-repeat="conflict in conflicts">{{conflict.file}} has been touched by:<span ng-repeat="user in conflict.users"> {{user.github_handle}}</span></li>
+        <li ng-repeat="conflict in conflicts">{{conflict.file}} is being touched by:<span ng-repeat="user in conflict.users"> {{user.github_handle}}<span ng-show="user !== conflict.users[conflict.users.length-1]">,</span></span></li>
       </ul>
     </div>
 

--- a/src/client/app/dashboard/dashboard.js
+++ b/src/client/app/dashboard/dashboard.js
@@ -11,23 +11,83 @@ angular.module('dashboard', [])
   $scope.storage = {};
 
   $scope.conflicts = [];
-
-  // example $scope.conflicts collection
-  // ===================================
+  // example $scope.conflicts
+  // ========================
   // $scope.conflicts = [
   //   { file: 'test1.js',
   //     users: [
-  //       {github_handle: 'yaliceme'},
-  //       {github_handle: 'rhombus'}
+  //       { github_handle: 'yaliceme',
+  //         github_name: 'Alice Yu',
+  //         mod_type: 'M'
+  //       },
+  //       { github_handle: 'rhombus',
+  //         github_name: 'Diamond Wheeler',
+  //         mod_type: 'M'
+  //       }
   //     ]
   //   },
   //   { file: 'test2.js',
   //     users: [
-  //       {github_handle: 'alberthyunh'},
-  //       {github_handle: 'rossad'}
+  //       { github_handle: 'alberthyunh',
+  //         github_name: 'Albert Hyunh',
+  //         mod_type: 'M'
+  //       },
+  //       { github_handle: 'rossad',
+  //           github_name: 'Ross Davis',
+  //           mod_type: 'M'
+  //       }
   //     ]
   //   }
   // ];
+
+  var parseConflicts = function () {
+    var fileMap = {};
+    // example fileMap
+    // ===============
+    // fileMap = {
+    //   test1.js: [
+    //     { github_handle: 'yaliceme',
+    //       github_name: 'Alice Yu',
+    //       mod_type: 'M'
+    //     },
+    //     { github_handle: 'rhombus',
+    //       github_name: 'Diamond Wheeler',
+    //       mod_type: 'M'
+    //     }
+    //   ]
+    // };
+    var users = $scope.users;
+    var dashboard = $scope.dashboard;
+
+    for (var i = 0; i < users.length; i++) {
+      var thisUser = users[i];
+      if (thisUser.last_pulled_commit_sha1 === dashboard.last_commit_sha1) {
+        // thisUser is up to date (green), so add their affected files to fileMap
+        var theseDiffs = thisUser.diffs;
+        for (var j = 0; j < theseDiffs.length; j++) {
+          var thisDiff = theseDiffs[j];
+          if (!fileMap[thisDiff.file]) {
+            fileMap[thisDiff.file] = [];
+          }
+          fileMap[thisDiff.file].push({
+            github_handle: thisUser.github_handle,
+            github_name: thisUser.github_name,
+            mod_type: thisDiff.mod_type
+          });
+        }
+      }
+    }
+
+    for (var file in fileMap) {
+      if (fileMap[file].length > 1) {
+        // file is being affected by multiple people -> potential conflict
+        $scope.conflicts.push({
+          file: file,
+          users: fileMap[file]
+        });
+      }
+    }
+  };
 
   Socket.on('newUser', function (data) {
     // $scope.users.push(data);
@@ -72,7 +132,7 @@ angular.module('dashboard', [])
       $scope.loading = false;
       $scope.users = data.users;
       $scope.dashboard = data.dashboard;
-      console.log('users:', $scope.users);
+      parseConflicts();
     });
   };
 

--- a/src/client/app/dashboard/dashboard.js
+++ b/src/client/app/dashboard/dashboard.js
@@ -10,6 +10,25 @@ angular.module('dashboard', [])
   $scope.removed = false;
   $scope.storage = {};
 
+  $scope.conflicts = [];
+
+  // example $scope.conflicts collection
+  // ===================================
+  // $scope.conflicts = [
+  //   { file: 'test1.js',
+  //     users: [
+  //       {github_handle: 'yaliceme'},
+  //       {github_handle: 'rhombus'}
+  //     ]
+  //   },
+  //   { file: 'test2.js',
+  //     users: [
+  //       {github_handle: 'alberthyunh'},
+  //       {github_handle: 'rossad'}
+  //     ]
+  //   }
+  // ];
+
   Socket.on('newUser', function (data) {
     // $scope.users.push(data);
   });

--- a/src/client/styles/style.css
+++ b/src/client/styles/style.css
@@ -441,6 +441,15 @@
     word-wrap: break-word;
   }
 
+  .potentialConflicts {
+    background-color: #ff8533;
+    font-size: 12px;
+    padding: 5px 5px 5px 5px;
+    margin: 10px 0px 10px 0px;
+    font-family: 'Montserrat', serif;
+    word-wrap: break-word;
+  }
+
   .users {
     margin: 25px 0px 25px 0px;
     font-family: 'Montserrat', serif;
@@ -1037,6 +1046,15 @@
     font-family: 'Montserrat', serif;
   }
 
+  .potentialConflicts {
+    background-color: #ff8533;
+    font-size: 11px;
+    padding: 5px 5px 5px 5px;
+    margin: 10px 0px 10px 0px;
+    word-wrap: break-word;
+    font-family: 'Montserrat', serif;
+  }
+
   .users {
     margin: 25px 0px 25px 0px;
     font-family: 'Montserrat', serif;
@@ -1590,6 +1608,15 @@
     word-wrap: break-word;
   }
 
+  .potentialConflicts {
+    background-color: #ff8533;
+    font-size: 12px;
+    padding: 5px 5px 5px 5px;
+    margin: 10px 0px 10px 0px;
+    font-family: 'Montserrat', serif;
+    word-wrap: break-word;
+  }
+
   .users {
     margin: 25px 0px 25px 0px;
     font-family: 'Montserrat', serif;
@@ -2132,6 +2159,15 @@
 
   .lastCommit {
     background-color: #CAD8ED;
+    font-size: 14px;
+    padding: 5px 5px;
+    margin: 10px 0px 10px 0px;
+    font-family: 'Montserrat', serif;
+    word-wrap: break-word;
+  }
+
+  .potentialConflicts {
+    background-color: #ff8533;
     font-size: 14px;
     padding: 5px 5px;
     margin: 10px 0px 10px 0px;


### PR DESCRIPTION
#### What's this PR do?
Adds an orange bar at top of dashboard page, which only appears when there are potential merge conflicts among green (up-to-date) people. Lists the files and who is touching them.

#### What are the important parts of the code?
Dashboard.html / dashboard.js on client side.

#### How should this be tested by the reviewer?
Pull down, run, and test it with various dummy data where you do and don't expect potential conflicts. Verify that the "potential conflicts" bar only shows up when it should, and show the correct data.

Some handy example queries:
INSERT into users (github_id, github_handle, github_name, github_avatar, github_token) values (1234567, 'rhombus', 'Diamond Wheeler', 'diamond.jpg', 'tokentokentokentoken');
INSERT into users_dashboards (users_github_id, dashboards_id, set_up, signature_hash) values (1234567, 1, 1, '1234567@1');
INSERT into diffs (file, mod_type, users_dashboards_signature_hash) values ('diamond.js', 'M', '1234567@1');

#### Is any other information necessary to understand this?
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
#### Screenshots (if appropriate)