### PR TITLE
Enforce use of brackets for controller dependencies

### DIFF
--- a/src/client/app/about/about.js
+++ b/src/client/app/about/about.js
@@ -1,5 +1,4 @@
 "use strict";
 angular.module('about', [])
-.controller('AboutController', ['$scope', 'RequestFactory', '$http', function($scope, RequestFactory, $http){
-
+.controller('AboutController', ['$scope', 'RequestFactory', '$http', function ($scope, RequestFactory, $http) {
 }]);

--- a/src/client/app/add/add.js
+++ b/src/client/app/add/add.js
@@ -1,6 +1,6 @@
 "use strict";
 angular.module('add', [])
-.controller('AddController', ['$scope', 'RequestFactory', '$http', 'Socket', '$location', '$timeout', '$cookies',function($scope, RequestFactory, $http, Socket, $location, $timeout, $cookies){
+.controller('AddController', ['$scope', 'RequestFactory', '$http', 'Socket', '$location', '$timeout', '$cookies', function ($scope, RequestFactory, $http, Socket, $location, $timeout, $cookies) {
   $scope.subsc = [];
   $scope.loading = true;
   var linked = [];

--- a/src/client/app/dashboard/dashboard.js
+++ b/src/client/app/dashboard/dashboard.js
@@ -1,6 +1,6 @@
 "use strict";
 angular.module('dashboard', [])
-.controller('DashboardController', function ($scope, $routeParams, RequestFactory, Socket, $cookies) {
+.controller('DashboardController', ['$scope', '$routeParams', 'RequestFactory', 'Socket', '$cookies', function ($scope, $routeParams, RequestFactory, Socket, $cookies) {
   $scope.orgName = $routeParams.orgName;
   $scope.repoName = $routeParams.repoName;
   $scope.repoLink = 'https://github.com/' + $routeParams.orgName + '/' + $routeParams.repoName;
@@ -45,7 +45,7 @@ angular.module('dashboard', [])
   // ];
 
   var parseConflicts = function () {
-    $scope.conflicts = [];  
+    $scope.conflicts = [];
     var fileMap = {};
     // example fileMap
     // ===============
@@ -180,4 +180,4 @@ angular.module('dashboard', [])
   };
 
   $scope.getDashboard();
-});
+}]);

--- a/src/client/app/home/home.js
+++ b/src/client/app/home/home.js
@@ -1,6 +1,6 @@
 "use strict";
 angular.module('home', [])
-.controller('HomeController', function($scope, RequestFactory, AuthFactory, $cookies, Socket){
+.controller('HomeController', ['$scope', 'RequestFactory', 'AuthFactory', '$cookies', 'Socket', function ($scope, RequestFactory, AuthFactory, $cookies, Socket) {
   $scope.empty = false;
   $scope.loading = true;
   var githubId = $cookies.get('githubId');
@@ -34,4 +34,4 @@ angular.module('home', [])
   };
 
   initializeDashboardList();
-});
+}]);

--- a/src/client/app/login/login.js
+++ b/src/client/app/login/login.js
@@ -1,8 +1,8 @@
 "use strict";
 angular.module('login', [])
-.controller('LoginController', function($scope, $cookies, $window, $location, RequestFactory){
-  $scope.isActivePage = function(viewLocation) {
+.controller('LoginController', ['$scope', '$cookies', '$window', '$location','RequestFactory', function ($scope, $cookies, $window, $location, RequestFactory) {
+  $scope.isActivePage = function (viewLocation) {
     $scope.welcomeString = "<span>Welcome, "+$cookies.get('githubName')+"!</span>";
     return viewLocation === $location.path();
   };
-});
+}]);

--- a/src/client/app/logout/logout.js
+++ b/src/client/app/logout/logout.js
@@ -1,6 +1,6 @@
 "use strict";
 angular.module('logout', [])
-.controller('LogoutController', function(AuthFactory){
+.controller('LogoutController', ['AuthFactory', function (AuthFactory) {
   AuthFactory.eatCookies();
   AuthFactory.logout();
-});
+}]);

--- a/src/client/app/services/services.js
+++ b/src/client/app/services/services.js
@@ -3,7 +3,7 @@ var helper = angular.module("helper", []);
 
 // all GET/POST requests will return res.data in a promise
 // DELETE request does not return anything
-helper.factory('RequestFactory', function($http, $location) {
+helper.factory('RequestFactory', ['$http', '$location', function ($http, $location) {
   var getRepos = function(callback){
     $http({
       method: 'GET',
@@ -96,9 +96,9 @@ helper.factory('RequestFactory', function($http, $location) {
     getRepos: getRepos,
     getPage: getPage
   };
-});
+}]);
 
-helper.factory('AuthFactory', function($cookies, $http, $location) {
+helper.factory('AuthFactory', ['$cookies', '$http', '$location', function ($cookies, $http, $location) {
   var authRoutes = ['/', '/add', '/:orgName/:repoName', '/:orgName/:repoName/setup', '/about'];
 
   var isAuth = function () {
@@ -126,7 +126,7 @@ helper.factory('AuthFactory', function($cookies, $http, $location) {
     eatCookies: eatCookies,
     logout: logout
   };
-});
+}]);
 
 helper.factory('Socket', ['socketFactory', function (socketFactory) {
   return socketFactory();

--- a/src/client/app/setup/setup.js
+++ b/src/client/app/setup/setup.js
@@ -1,6 +1,6 @@
 "use strict";
 angular.module('setup', [])
-.controller('SetupController', ['$scope', '$window', 'RequestFactory', '$location', '$routeParams', function($scope, $window, RequestFactory, $location, $routeParams){
+.controller('SetupController', ['$scope', '$window', 'RequestFactory', '$location', '$routeParams', function ($scope, $window, RequestFactory, $location, $routeParams) {
   var orgName = $scope.orgName = $routeParams.orgName;
   var repoName = $scope.repoName = $routeParams.repoName;
   RequestFactory.getSetupInfo(orgName, repoName)


### PR DESCRIPTION
#### What's this PR do?
Makes it so that all controllers list dependencies as strings inside brackets, for minification. Also enforce a consistent whitespace convention for the anonymous controller functions, i.e. function (dep1, dep2) {}

#### What are the important parts of the code?
All controller .js files in src/client/app

#### How should this be tested by the reviewer?
Pull down, make sure all views still work as before + visual inspection

#### Is any other information necessary to understand this?
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
#### Screenshots (if appropriate)
