### PR TITLE
Change github API auth to include private repos

### DIFF
--- a/src/server/config/auth.js
+++ b/src/server/config/auth.js
@@ -60,7 +60,7 @@ module.exports = function (app) {
 
   // GITHUB LOGIN
   app.get('/login/github',
-    passport.authenticate('github', {scope: ['user:email','read:org', 'public_repo']}));
+    passport.authenticate('github', {scope: ['user:email','read:org', 'repo']}));
 
   app.get('/login/github_callback',
     passport.authenticate('github', {failureRedirect: '/'}),


### PR DESCRIPTION
#### What's this PR do?
Change oAuth request to github api to include access to private repos
#### What are the important parts of the code?
auth.js line 63, 3rd item in scope key of authenticate object changed to repo from public_repo
#### How should this be tested by the reviewer?
pull down change, clear cookies, login to gitspy, approve new access.  Try to add new repo/dashboard, look for you private repos
#### Is any other information necessary to understand this?
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
#### Screenshots (if appropriate)
